### PR TITLE
Allow missing values in the config

### DIFF
--- a/projects/ngx-duration-picker/src/lib/duration-picker.model.ts
+++ b/projects/ngx-duration-picker/src/lib/duration-picker.model.ts
@@ -1,19 +1,19 @@
 export interface DurationPickerOptions {
-  showNegative: boolean;
-  showButtons: boolean;
-  showPreview: boolean;
-  showLetters: boolean;
-  showYears: boolean;
-  showMonths: boolean;
-  showWeeks: boolean;
-  showDays: boolean;
-  showHours: boolean;
-  showMinutes: boolean;
-  showSeconds: boolean;
-  zeroValue: string | null;
-  previewFormat: string;
-  customOutputFormat: string;
-  labels: {
+  showNegative?: boolean;
+  showButtons?: boolean;
+  showPreview?: boolean;
+  showLetters?: boolean;
+  showYears?: boolean;
+  showMonths?: boolean;
+  showWeeks?: boolean;
+  showDays?: boolean;
+  showHours?: boolean;
+  showMinutes?: boolean;
+  showSeconds?: boolean;
+  zeroValue?: string | null;
+  previewFormat?: string;
+  customOutputFormat?: string;
+  labels?: {
     years?: string;
     months?: string;
     weeks?: string;
@@ -22,7 +22,7 @@ export interface DurationPickerOptions {
     minutes?: string;
     seconds?: string;
   };
-  unitSteps: {
+  unitSteps?: {
     years?: number;
     months?: number;
     weeks?: number;


### PR DESCRIPTION
Allow missing values so DurationPickerOptions type would be convenient to use.